### PR TITLE
Prevent php 8.4+ deprecation notices about $parcellabelsPDF in StoreOrdersResponseType

### DIFF
--- a/src/Business/StoreOrdersResponseType.php
+++ b/src/Business/StoreOrdersResponseType.php
@@ -18,6 +18,11 @@ class StoreOrdersResponseType
     protected mixed $shipmentResponses;
 
     /**
+     * Contains response data for the generated PDF label.
+     */
+    protected string $parcellabelsPDF;
+
+    /**
      * @return OutputType|null
      */
     public function getOutput(): ?OutputType

--- a/src/Business/StoreOrdersResponseType.php
+++ b/src/Business/StoreOrdersResponseType.php
@@ -29,7 +29,15 @@ class StoreOrdersResponseType
     {
         return $this->output ?? null;
     }
-
+    
+    /**
+     * @return string|null
+     */
+    public function getPDF(): ?string
+    {
+        return $this->parcellabelsPDF ?? null;
+    }
+    
     /**
      * @return ShipmentResponse[]
      */


### PR DESCRIPTION
These changes add a property for `parcellabelsPDF` and adds a getter for the generated PDF to prevent deprecation notices on php 8.4+.