### PR TITLE
Bugfix: handling of multiple OutputType

### DIFF
--- a/src/Business/ParcelInformationType.php
+++ b/src/Business/ParcelInformationType.php
@@ -19,9 +19,9 @@ class ParcelInformationType
 
     /**
      * The content for the parcel.
-     * @var OutputType
+     * @var array
      */
-    protected OutputType $output;
+    protected array $output = [];
 
     /**
      * @return string|null
@@ -40,10 +40,20 @@ class ParcelInformationType
     }
 
     /**
-     * @return OutputType|null
+     * @return array
      */
-    public function getOutput(): ?OutputType
+    public function getOutput(): array
     {
-        return $this->output ?? null;
+        return $this->output;
+    }
+
+    /**
+     * @var OutputType
+     * @return ParcelInformationType
+     */
+    public function addOutput(OutputType $o): self
+    {
+        $this->output[] = $o;
+        return $this;
     }
 }


### PR DESCRIPTION
When setting multiple PrintOptions, an exception gets thrown in the Api::me()->storeOrders($authentication, $storeOrders) call due to passing an array when an Object is expect. 

This bugfix has been tested against the DPD sandbox for requesting PDF and ZPL labels for a single order. 

Simplified example:

`$storeOrders = (new StoreOrders())
            ->setPrintOptions(
                (new PrintOptions())
                    ->addPrintOption(
                        (new PrintOption())
                            ->setPaperFormatA6()
                            ->setOutputFormat(OutputFormatType::pdf())
                    )
                    ->addPrintOption(
                        (new PrintOption())
                            ->setPaperFormatA6()
                            ->setOutputFormat(OutputFormatType::zpl())
                    )
                    ->setSplitByParcel(true)
            )
            ->addOrder($createShipmentOrderRequest);

$response = Api::me()->storeOrders($authentication, $storeOrders);
            if ($response instanceof StoreOrdersResponseType) {
                foreach ($response->getShipmentResponses() as $shipmentResponse) {
                    $parcelInfo = $shipmentResponse->getParcelInformation();
                    if ($shipmentResponse instanceof ShipmentResponse && $parcelInfo instanceof ParcelInformationType
                        && $parcelInfo->getParcelLabelNumber() && $parcelInfo->getOutput()) {
                        $parcelOutputs = $parcelInfo->getOutput();
                        foreach ($parcelOutputs as $parcelOutput) {
                            if ($parcelOutput->getFormat() == OutputFormatType::pdf()) {
                                // Apply PDF logic
                            } else if ($parcelOutput->getFormat() == OutputFormatType::zpl()) {
                                // Apply ZPLlogic
                            }
                        }
                    }
                }
            }`